### PR TITLE
Add `strlen` callback to array_filter

### DIFF
--- a/src/services/LetteringService.php
+++ b/src/services/LetteringService.php
@@ -69,7 +69,7 @@ class LetteringService extends Component
             $part = '<span class="'.substr($class, 0, -1) . $count . '" aria-hidden="true">' . $part . '</span>' . $after;
             $count = $count + 1;
             return $part;
-        }, \array_filter($parts));
+        }, \array_filter($parts, 'strlen'));
 
         $ariaLabel = Template::raw(' aria-label="'. StringHelper::collapseWhitespace(trim(strip_tags($text))) .'"');
         $joined = Template::raw( implode('', $formattedParts) );


### PR DESCRIPTION
Applies to characters like `0`, for example.

Adding the strlen callback means that falsey values don't accidentally get stripped out.

Fixes #2 