### PR TITLE
Fixes issue #4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "mmikkel/lettering",
     "description": "Like Lettering.js, but in Twig",
     "type": "craft-plugin",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "keywords": [
         "craft",
         "cms",

--- a/src/services/LetteringService.php
+++ b/src/services/LetteringService.php
@@ -13,6 +13,7 @@ namespace mmikkel\lettering\services;
 use craft\base\Component;
 use craft\helpers\Template;
 use craft\helpers\StringHelper;
+use craft\helpers\ArrayHelper;
 
 class LetteringService extends Component
 {
@@ -53,7 +54,7 @@ class LetteringService extends Component
 
         switch ($class) {
             case 'words' :
-                $parts = StringHelper::splitOnWords(StringHelper::stripHtml($text));
+                $parts = $this->_splitWords(StringHelper::stripHtml($text));
                 break;
             case 'lines' :
                 $parts = StringHelper::lines(StringHelper::stripHtml($text));
@@ -81,5 +82,18 @@ class LetteringService extends Component
         ];
 
         return $result;
+    }
+	 
+    /**
+     * Overriding the splitWords function from StringHelper
+     * @param $str
+     * @return array
+     */
+    private function _splitWords($str): array {
+        // Split on any character or punctuation
+        // Reference: http://www.regular-expressions.info/unicode.html
+        preg_match_all('/[^\p{Z}]+/u', $str, $matches);
+
+        return ArrayHelper::filterEmptyStringsFromArray($matches[0]);
     }
 }


### PR DESCRIPTION
@mmikkel - this fixes issue #4 by setting the regex for splitting words to leave punctuation intact (it now *only* splits on `\p{Z}`, Unicode space or separator characters.)